### PR TITLE
wip

### DIFF
--- a/ui/proxy-config.json
+++ b/ui/proxy-config.json
@@ -1,111 +1,136 @@
 {
   "/password/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/users": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/members/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/groups/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/version": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/things/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/connect": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/channels/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/http/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false,
     "pathRewrite": {
       "^/http": ""
     }
   },
   "/reader/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false,
     "pathRewrite": {
       "^/reader": ""
     }
   },
   "/bootstrap/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false,
     "pathRewrite": {
       "^/bootstrap": ""
     }
   },
   "/browse": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/twins/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/states/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/tokens/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/features/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/sinks/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/agents/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/agent_groups/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/policies/agent/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/policies/dataset/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/agents/backends/*": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/agents/backends/taps": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/agents/backends/handlers": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   },
   "/agents/backends/inputs": {
-    "target": "http://localhost:80/api/v1",
+    "target": "https://stg.orb.live/api/v1",
+    "changeOrigin": true,
     "secure": false
   }
 }

--- a/ui/src/app/@theme/styles/_overrides.scss
+++ b/ui/src/app/@theme/styles/_overrides.scss
@@ -139,3 +139,9 @@
   min-width: 800px;
   max-height: calc(100vh - 300px);
 }
+
+.orb-table-small {
+  min-height: calc(25vh);
+  min-width: 600px;
+  max-height: calc(25vh);
+}

--- a/ui/src/app/@theme/styles/_overrides.scss
+++ b/ui/src/app/@theme/styles/_overrides.scss
@@ -99,9 +99,10 @@
 
   nb-card nb-list {
     @include nb-scrollbars(
-        nb-theme(card-scrollbar-color),
-        nb-theme(card-scrollbar-background-color),
-        nb-theme(card-scrollbar-width));
+      nb-theme(card-scrollbar-color),
+      nb-theme(card-scrollbar-background-color),
+      nb-theme(card-scrollbar-width)
+    );
   }
 
   .table {

--- a/ui/src/app/common/interfaces/orb/agent.policy.interface.ts
+++ b/ui/src/app/common/interfaces/orb/agent.policy.interface.ts
@@ -75,4 +75,8 @@ export interface AgentPolicy extends OrbEntity {
    * Either JSON or YAML compatible string;
    */
   policy_data?: string;
+
+  /** HELPERS */
+  datasets?: any[];
+  groups?: any[];
 }

--- a/ui/src/app/common/interfaces/orb/dataset.policy.interface.ts
+++ b/ui/src/app/common/interfaces/orb/dataset.policy.interface.ts
@@ -45,4 +45,11 @@ export interface Dataset extends OrbEntity {
    * Dataset Metadata {{[propName: string]: string}}
    */
   dataset_metadata?: any;
+
+  /**
+   * Helper section with aggregate information about dataset
+   */
+  agent_policy?: any;
+  agent_group?: any;
+  sinks?: any[];
 }

--- a/ui/src/app/common/services/agents/agent.groups.service.ts
+++ b/ui/src/app/common/services/agents/agent.groups.service.ts
@@ -1,22 +1,13 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of, scheduled } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import 'rxjs/add/observable/empty';
 
 import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
-import {
-  NgxDatabalePageInfo,
-  OrbPagination,
-} from 'app/common/interfaces/orb/pagination.interface';
+import { OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { environment } from 'environments/environment';
-import {
-  catchError,
-  delay,
-  expand,
-  map, scan,
-  takeWhile,
-} from 'rxjs/operators';
+import { catchError, expand, map, scan, takeWhile } from 'rxjs/operators';
 @Injectable()
 export class AgentGroupsService {
   constructor(
@@ -82,7 +73,7 @@ export class AgentGroupsService {
   }
 
   getAllAgentGroups() {
-    let page = {
+    const page = {
       order: 'name',
       dir: 'asc',
       limit: 100,
@@ -95,7 +86,7 @@ export class AgentGroupsService {
         return data.next ? this.getAgentGroups(data.next) : Observable.empty();
       }),
       takeWhile((data) => data.next !== undefined),
-      map((page) => page.data),
+      map((_page) => _page.data),
       scan((acc, v) => [...acc, ...v]),
     );
   }
@@ -103,7 +94,7 @@ export class AgentGroupsService {
   getAgentGroups(page: OrbPagination<AgentGroup>) {
     const { order, dir, offset, limit } = page;
 
-    let params = new HttpParams()
+    const params = new HttpParams()
       .set('order', order)
       .set('dir', dir)
       .set('offset', offset.toString())
@@ -112,13 +103,18 @@ export class AgentGroupsService {
     return this.http
       .get(environment.agentGroupsUrl, { params })
       .map((resp: any) => {
-        const { order, direction: dir, offset, limit, total, agentGroups: data } = resp;
-        const next = offset + limit < total && {
+        const {
+          offset: _offset,
+          total,
+          limit: _limit,
+          agentGroups: data,
+        } = resp;
+        const next = _offset + limit < total && {
           limit,
           order,
           dir,
-          offset: (parseInt(offset, 10) + parseInt(limit, 10)).toString(),
-        }
+          offset: (parseInt(_offset, 10) + parseInt(_limit, 10)).toString(),
+        };
 
         return {
           order,

--- a/ui/src/app/common/services/agents/agent.policies.service.ts
+++ b/ui/src/app/common/services/agents/agent.policies.service.ts
@@ -109,7 +109,7 @@ export class AgentPoliciesService {
     const page = {
       order: 'name',
       dir: 'asc',
-      limit: 20,
+      limit: 100,
       data: [],
       offset: 0,
     } as OrbPagination<AgentPolicy>;

--- a/ui/src/app/common/services/agents/agent.policies.service.ts
+++ b/ui/src/app/common/services/agents/agent.policies.service.ts
@@ -18,7 +18,7 @@ import {
 } from 'rxjs/operators';
 
 // default filters
-const defLimit: number = 100;
+const defLimit: number = 50;
 const defOrder: string = 'name';
 const defDir = 'asc';
 

--- a/ui/src/app/common/services/agents/agent.policies.service.ts
+++ b/ui/src/app/common/services/agents/agent.policies.service.ts
@@ -4,24 +4,13 @@ import { Observable, of } from 'rxjs';
 import 'rxjs/add/observable/empty';
 
 import { AgentPolicy } from 'app/common/interfaces/orb/agent.policy.interface';
-import {
-  NgxDatabalePageInfo,
-  OrbPagination,
-} from 'app/common/interfaces/orb/pagination.interface';
+import { OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { environment } from 'environments/environment';
-import {
-  catchError,
-  expand,
-  map, scan,
-  takeWhile,
-} from 'rxjs/operators';
+import { catchError, expand, map, scan, takeWhile } from 'rxjs/operators';
 
-// default filters
-const defLimit: number = 50;
 @Injectable()
 export class AgentPoliciesService {
-
   backendsCache: OrbPagination<{ [propName: string]: any }>;
 
   constructor(
@@ -121,13 +110,13 @@ export class AgentPoliciesService {
           : Observable.empty();
       }),
       takeWhile((data) => data.next !== undefined),
-      map((page) => page.data),
+      map((_page) => _page.data),
       scan((acc, v) => [...acc, ...v]),
     );
   }
 
   getAgentsPolicies(page: OrbPagination<AgentPolicy>) {
-    let params = new HttpParams()
+    const params = new HttpParams()
       .set('order', page.order)
       .set('dir', page.dir)
       .set('offset', page.offset.toString())

--- a/ui/src/app/common/services/agents/agents.service.ts
+++ b/ui/src/app/common/services/agents/agents.service.ts
@@ -7,10 +7,7 @@ import { Agent } from 'app/common/interfaces/orb/agent.interface';
 import { OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { environment } from 'environments/environment';
-import {
-  expand,
-  map, scan, takeWhile,
-} from 'rxjs/operators';
+import { expand, map, scan, takeWhile } from 'rxjs/operators';
 
 export enum AvailableOS {
   DOCKER = 'docker',
@@ -144,7 +141,7 @@ export class AgentsService {
         return data.next ? this.getAgents(data.next) : EMPTY;
       }),
       takeWhile((data) => data.next !== undefined),
-      map((page) => page.data),
+      map((_page) => _page.data),
       scan((acc, v) => [...acc, ...v]),
     );
   }
@@ -167,7 +164,15 @@ export class AgentsService {
       .get(`${environment.agentsUrl}`, { params })
       .pipe(
         map((resp: any) => {
-          const { order, direction: dir, offset, limit, total, agents, tags } = resp;
+          const {
+            order,
+            direction: dir,
+            offset,
+            limit,
+            total,
+            agents,
+            tags,
+          } = resp;
           const next = offset + limit < total && {
             limit,
             order,

--- a/ui/src/app/common/services/agents/agents.service.ts
+++ b/ui/src/app/common/services/agents/agents.service.ts
@@ -131,7 +131,7 @@ export class AgentsService {
   }
 
   getAllAgents(tags?: any) {
-    const pageInfo = {
+    const page = {
       order: 'name',
       dir: 'asc',
       limit: 20,
@@ -139,7 +139,7 @@ export class AgentsService {
       offset: 0,
       tags,
     } as OrbPagination<Agent>;
-    return this.getAgents(pageInfo).pipe(
+    return this.getAgents(page).pipe(
       expand((data) => {
         return data.next ? this.getAgents(data.next) : EMPTY;
       }),

--- a/ui/src/app/common/services/agents/agents.service.ts
+++ b/ui/src/app/common/services/agents/agents.service.ts
@@ -134,7 +134,7 @@ export class AgentsService {
     const pageInfo = {
       order: 'name',
       dir: 'asc',
-      limit: 100,
+      limit: 20,
       data: [],
       offset: 0,
       tags,
@@ -167,17 +167,17 @@ export class AgentsService {
       .get(`${environment.agentsUrl}`, { params })
       .pipe(
         map((resp: any) => {
-          const { order, direction, offset, limit, total, agents, tags } = resp;
+          const { order, direction: dir, offset, limit, total, agents, tags } = resp;
           const next = offset + limit < total && {
             limit,
             order,
-            dir: direction,
+            dir,
             tags,
             offset: (parseInt(offset, 10) + parseInt(limit, 10)).toString(),
           };
           return {
             order,
-            dir: direction,
+            dir,
             offset,
             limit,
             total,

--- a/ui/src/app/common/services/agents/agents.service.ts
+++ b/ui/src/app/common/services/agents/agents.service.ts
@@ -134,7 +134,7 @@ export class AgentsService {
     const page = {
       order: 'name',
       dir: 'asc',
-      limit: 20,
+      limit: 100,
       data: [],
       offset: 0,
       tags,

--- a/ui/src/app/common/services/dataset/dataset.policies.service.ts
+++ b/ui/src/app/common/services/dataset/dataset.policies.service.ts
@@ -19,39 +19,10 @@ const defDir = 'asc';
 
 @Injectable()
 export class DatasetPoliciesService {
-  paginationCache: any = {};
-
-  cache: OrbPagination<Dataset>;
-
   constructor(
     private http: HttpClient,
     private notificationsService: NotificationsService,
-  ) {
-    this.clean();
-  }
-
-  public static getDefaultPagination(): OrbPagination<Dataset> {
-    return {
-      limit: defLimit,
-      order: defOrder,
-      dir: defDir,
-      offset: 0,
-      total: 0,
-      data: null,
-    };
-  }
-
-  clean() {
-    this.cache = {
-      limit: defLimit,
-      offset: 0,
-      order: defOrder,
-      total: 0,
-      dir: defDir,
-      data: [],
-    };
-    this.paginationCache = {};
-  }
+  ) {}
 
   addDataset(datasetItem: Dataset) {
     return this.http
@@ -118,10 +89,15 @@ export class DatasetPoliciesService {
   }
 
   getAllDatasets() {
-    this.clean();
-    const pageInfo = DatasetPoliciesService.getDefaultPagination();
+    const page = {
+      order: 'name',
+      dir: 'asc',
+      limit: 100,
+      data: [],
+      offset: 0,
+    } as OrbPagination<Dataset>;
 
-    return this.getDatasetPolicies(pageInfo).pipe(
+    return this.getDatasetPolicies(page).pipe(
       expand((data) => {
         return data.next
           ? this.getDatasetPolicies(data.next)
@@ -133,87 +109,39 @@ export class DatasetPoliciesService {
     );
   }
 
-  getDatasetPolicies(pageInfo: NgxDatabalePageInfo, isFilter = false) {
-    let limit = pageInfo?.limit || this.cache.limit;
-    let order = pageInfo?.order || this.cache.order;
-    let dir = pageInfo?.dir || this.cache.dir;
-    let offset = pageInfo?.offset || 0;
-    let doClean = false;
-    let params = new HttpParams();
-
-    if (isFilter) {
-      if (pageInfo?.name) {
-        params = params.set('name', pageInfo.name);
-        // is filter different than last filter?
-        doClean =
-          !this.paginationCache?.name ||
-          this.paginationCache?.name !== pageInfo.name;
-      }
-      // was filtered, no longer
-    } else if (this.paginationCache?.isFilter === true) {
-      doClean = true;
-    }
-
-    if (
-      pageInfo.order !== this.cache.order ||
-      pageInfo.dir !== this.cache.dir
-    ) {
-      doClean = true;
-    }
-
-    if (doClean) {
-      this.clean();
-      offset = 0;
-      limit = this.cache.limit = pageInfo.limit;
-      dir = pageInfo.dir;
-      order = pageInfo.order;
-    }
-
-    if (this.paginationCache[offset]) {
-      return of(this.cache);
-    }
-    params = params
-      .set('offset', offset.toString())
-      .set('limit', limit.toString())
-      .set('order', order)
-      .set('dir', dir);
+  getDatasetPolicies(page: OrbPagination<Dataset>) {
+    let params = new HttpParams()
+    .set('order', page.order)
+    .set('dir', page.dir)
+    .set('offset', page.offset.toString())
+    .set('limit', page.limit.toString());
 
     return this.http
       .get(environment.datasetPoliciesUrl, { params })
-      .map((resp: any) => {
-        this.paginationCache[pageInfo?.offset / pageInfo?.limit || 0] = true;
-
-        // This is the position to insert the new data
-        const start = pageInfo?.offset;
-
-        const newData = [...this.cache.data];
-
-        newData.splice(start, resp.limit, ...resp.datasets);
-
-        this.cache = {
-          ...this.cache,
-          next: resp.offset + resp.limit < resp.total && {
-            limit: resp.limit,
-            offset: (
-              parseInt(resp.offset, 10) + parseInt(resp.limit, 10)
-            ).toString(),
-            order: 'name',
-            dir: 'desc',
-          },
-          limit: resp.limit,
-          offset: resp.offset,
-          dir: resp.direction,
-          order: resp.order,
-          total: resp.total,
-          data: newData,
-          name: pageInfo?.name,
-        };
-
-        return this.cache;
-      })
+      .pipe(
+        map((resp: any) => {
+          const { order, direction: dir, offset, limit, total, datasets: data, tags } = resp;
+          const next = offset + limit < total && {
+            limit,
+            order,
+            dir,
+            tags,
+            offset: (parseInt(offset, 10) + parseInt(limit, 10)).toString(),
+          };
+          return {
+            order,
+            dir,
+            offset,
+            limit,
+            total,
+            data,
+            next,
+          } as OrbPagination<Dataset>;
+        }),
+      )
       .catch((err) => {
         this.notificationsService.error(
-          'Failed to get Datasets of Policy',
+          'Failed to get Datasets',
           `Error: ${err.status} - ${err.statusText}`,
         );
         return Observable.throwError(err);

--- a/ui/src/app/common/services/dataset/dataset.policies.service.ts
+++ b/ui/src/app/common/services/dataset/dataset.policies.service.ts
@@ -1,21 +1,13 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import 'rxjs/add/observable/empty';
 
 import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
-import {
-  NgxDatabalePageInfo,
-  OrbPagination,
-} from 'app/common/interfaces/orb/pagination.interface';
+import { OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { environment } from 'environments/environment';
 import { expand, map, scan, takeWhile } from 'rxjs/operators';
-
-// default filters
-const defLimit: number = 100;
-const defOrder: string = 'name';
-const defDir = 'asc';
 
 @Injectable()
 export class DatasetPoliciesService {
@@ -104,23 +96,31 @@ export class DatasetPoliciesService {
           : Observable.empty();
       }),
       takeWhile((data) => data.next !== undefined),
-      map((page) => page.data),
+      map((_page) => _page.data),
       scan((acc, v) => [...acc, ...v]),
     );
   }
 
   getDatasetPolicies(page: OrbPagination<Dataset>) {
-    let params = new HttpParams()
-    .set('order', page.order)
-    .set('dir', page.dir)
-    .set('offset', page.offset.toString())
-    .set('limit', page.limit.toString());
+    const params = new HttpParams()
+      .set('order', page.order)
+      .set('dir', page.dir)
+      .set('offset', page.offset.toString())
+      .set('limit', page.limit.toString());
 
     return this.http
       .get(environment.datasetPoliciesUrl, { params })
       .pipe(
         map((resp: any) => {
-          const { order, direction: dir, offset, limit, total, datasets: data, tags } = resp;
+          const {
+            order,
+            direction: dir,
+            offset,
+            limit,
+            total,
+            datasets: data,
+            tags,
+          } = resp;
           const next = offset + limit < total && {
             limit,
             order,

--- a/ui/src/app/common/services/orb.service.ts
+++ b/ui/src/app/common/services/orb.service.ts
@@ -1,7 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
-import { Agent } from 'app/common/interfaces/orb/agent.interface';
-import { AgentPolicy } from 'app/common/interfaces/orb/agent.policy.interface';
 import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
 import { Sink } from 'app/common/interfaces/orb/sink.interface';
 import { AgentGroupsService } from 'app/common/services/agents/agent.groups.service';
@@ -14,17 +12,13 @@ import {
   defer,
   EMPTY,
   forkJoin,
-  from,
   merge,
   Observable,
-  of,
   Subject,
   timer,
-  zip,
 } from 'rxjs';
 import {
   debounceTime,
-  filter,
   map,
   mergeMap,
   retry,
@@ -116,7 +110,7 @@ export class OrbService implements OnDestroy {
       )
       .reduce((acc, val) => acc.concat(val), [])
       .filter(this.onlyUnique);
-  };
+  }
 
   ngOnDestroy() {
     this.killPolling.next();
@@ -163,7 +157,7 @@ export class OrbService implements OnDestroy {
     // retrieve policy
     return this.policy.getAgentPolicyById(id).pipe(
       mergeMap((policy) =>
-      // need a way to get a dataset linked to a policy without having to filter it out
+        // need a way to get a dataset linked to a policy without having to filter it out
         this.dataset.getAllDatasets().pipe(
           map((_dataset) =>
             _dataset.filter((dataset) => policy.id === dataset.agent_policy_id),
@@ -177,27 +171,29 @@ export class OrbService implements OnDestroy {
             ).pipe(map((groups) => ({ datasets, groups, policy }))),
           ),
           // same for sinks
-          mergeMap(({datasets, groups}) => 
+          mergeMap(({ datasets, groups }) =>
             forkJoin(
               datasets
                 .map((dataset) => dataset?.sink_ids)
                 .reduce((acc, val) => acc.concat(val), [])
-                .map((sinkId) => this.sink.getSinkById(sinkId))
-            ).pipe(map((sinks) => ({ datasets, sinks, policy, groups })))
+                .map((sinkId) => this.sink.getSinkById(sinkId)),
+            ).pipe(map((sinks) => ({ datasets, sinks, policy, groups }))),
           ),
         ),
       ),
       // from here on I can map to any shape I like
       // dataset list uses the info below
-      map(({datasets, sinks, policy, groups}) => ({
+      map(({ datasets, sinks, policy, groups }) => ({
         datasets: datasets.map((dataset) => ({
           ...dataset,
-          agent_group: groups.find((group) => group.id === dataset.agent_group_id),
+          agent_group: groups.find(
+            (group) => group.id === dataset.agent_group_id,
+          ),
           agent_policy: policy,
           sinks: sinks.filter((sink) => dataset.sink_ids.includes(sink.id)),
         })),
         sinks,
-        policy: {...policy, groups, datasets},
+        policy: { ...policy, groups, datasets },
         groups,
       })),
     );

--- a/ui/src/app/common/services/sinks/sinks.service.ts
+++ b/ui/src/app/common/services/sinks/sinks.service.ts
@@ -3,19 +3,11 @@ import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import 'rxjs/add/observable/empty';
 
-import {
-  NgxDatabalePageInfo,
-  OrbPagination,
-} from 'app/common/interfaces/orb/pagination.interface';
+import { OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
 import { Sink } from 'app/common/interfaces/orb/sink.interface';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { environment } from 'environments/environment';
-import {
-  catchError,
-  expand,
-  map, scan,
-  takeWhile,
-} from 'rxjs/operators';
+import { catchError, expand, map, scan, takeWhile } from 'rxjs/operators';
 
 @Injectable()
 export class SinksService {
@@ -85,13 +77,13 @@ export class SinksService {
         return data.next ? this.getSinks(data.next) : Observable.empty();
       }),
       takeWhile((data) => data.next !== undefined),
-      map((page) => page.data),
+      map((_page) => _page.data),
       scan((acc, v) => [...acc, ...v]),
     );
   }
 
   getSinks(page: OrbPagination<Sink>) {
-    let params = new HttpParams()
+    const params = new HttpParams()
       .set('order', page.order)
       .set('dir', page.dir)
       .set('offset', page.offset.toString())
@@ -101,7 +93,15 @@ export class SinksService {
       .get(environment.sinksUrl, { params })
       .pipe(
         map((resp: any) => {
-          const { order, direction: dir, offset, limit, total, sinks: data, tags } = resp;
+          const {
+            order,
+            direction: dir,
+            offset,
+            limit,
+            total,
+            sinks: data,
+            tags,
+          } = resp;
           const next = offset + limit < total && {
             limit,
             order,

--- a/ui/src/app/common/services/sinks/sinks.service.ts
+++ b/ui/src/app/common/services/sinks/sinks.service.ts
@@ -17,11 +17,6 @@ import {
   takeWhile,
 } from 'rxjs/operators';
 
-// default filters
-const defLimit: number = 100;
-const defOrder: string = 'name';
-const defDir = 'asc';
-
 @Injectable()
 export class SinksService {
   paginationCache: any = {};
@@ -31,32 +26,7 @@ export class SinksService {
   constructor(
     private http: HttpClient,
     private notificationsService: NotificationsService,
-  ) {
-    this.clean();
-  }
-
-  public static getDefaultPagination(): OrbPagination<Sink> {
-    return {
-      limit: defLimit,
-      order: defOrder,
-      dir: defDir,
-      offset: 0,
-      total: 0,
-      data: null,
-    };
-  }
-
-  clean() {
-    this.cache = {
-      limit: defLimit,
-      offset: 0,
-      order: defOrder,
-      total: 0,
-      dir: defDir,
-      data: [],
-    };
-    this.paginationCache = {};
-  }
+  ) {}
 
   addSink(sinkItem: Sink) {
     return this.http
@@ -102,10 +72,15 @@ export class SinksService {
   }
 
   getAllSinks() {
-    this.clean();
-    const pageInfo = SinksService.getDefaultPagination();
+    const page = {
+      order: 'name',
+      dir: 'asc',
+      limit: 20,
+      data: [],
+      offset: 0,
+    } as OrbPagination<Sink>;
 
-    return this.getSinks(pageInfo).pipe(
+    return this.getSinks(page).pipe(
       expand((data) => {
         return data.next ? this.getSinks(data.next) : Observable.empty();
       }),
@@ -115,84 +90,36 @@ export class SinksService {
     );
   }
 
-  getSinks(pageInfo: NgxDatabalePageInfo, isFilter = false) {
-    let limit = pageInfo?.limit || this.cache.limit;
-    let order = pageInfo?.order || this.cache.order;
-    let dir = pageInfo?.dir || this.cache.dir;
-    let offset = pageInfo?.offset || 0;
-    let doClean = false;
-    let params = new HttpParams();
-
-    if (isFilter) {
-      if (pageInfo?.name) {
-        params = params.set('name', pageInfo.name);
-        // is filter different than last filter?
-        doClean =
-          !this.paginationCache?.name ||
-          this.paginationCache?.name !== pageInfo.name;
-      }
-      // was filtered, no longer
-    } else if (this.paginationCache?.isFilter === true) {
-      doClean = true;
-    }
-
-    if (
-      pageInfo.order !== this.cache.order ||
-      pageInfo.dir !== this.cache.dir
-    ) {
-      doClean = true;
-    }
-
-    if (doClean) {
-      this.clean();
-      offset = 0;
-      limit = this.cache.limit = pageInfo.limit;
-      dir = pageInfo.dir;
-      order = pageInfo.order;
-    }
-
-    if (this.paginationCache[offset]) {
-      return of(this.cache);
-    }
-    params = params
-      .set('offset', offset.toString())
-      .set('limit', limit.toString())
-      .set('order', order)
-      .set('dir', dir);
+  getSinks(page: OrbPagination<Sink>) {
+    let params = new HttpParams()
+      .set('order', page.order)
+      .set('dir', page.dir)
+      .set('offset', page.offset.toString())
+      .set('limit', page.limit.toString());
 
     return this.http
       .get(environment.sinksUrl, { params })
-      .map((resp: any) => {
-        this.paginationCache[pageInfo?.offset / pageInfo?.limit || 0] = true;
-
-        // This is the position to insert the new data
-        const start = pageInfo?.offset;
-
-        const newData = [...this.cache.data];
-
-        newData.splice(start, resp.limit, ...resp.sinks);
-
-        this.cache = {
-          ...this.cache,
-          next: resp.offset + resp.limit < resp.total && {
-            limit: resp.limit,
-            offset: (
-              parseInt(resp.offset, 10) + parseInt(resp.limit, 10)
-            ).toString(),
-            order: 'name',
-            dir: 'desc',
-          },
-          limit: resp.limit,
-          offset: resp.offset,
-          dir: resp.direction,
-          order: resp.order,
-          total: resp.total,
-          data: newData,
-          name: pageInfo?.name,
-        };
-
-        return this.cache;
-      })
+      .pipe(
+        map((resp: any) => {
+          const { order, direction: dir, offset, limit, total, sinks: data, tags } = resp;
+          const next = offset + limit < total && {
+            limit,
+            order,
+            dir,
+            tags,
+            offset: (parseInt(offset, 10) + parseInt(limit, 10)).toString(),
+          };
+          return {
+            order,
+            dir,
+            offset,
+            limit,
+            total,
+            data,
+            next,
+          } as OrbPagination<Sink>;
+        }),
+      )
       .catch((err) => {
         this.notificationsService.error(
           'Failed to get Sinks',

--- a/ui/src/app/common/services/sinks/sinks.service.ts
+++ b/ui/src/app/common/services/sinks/sinks.service.ts
@@ -75,7 +75,7 @@ export class SinksService {
     const page = {
       order: 'name',
       dir: 'asc',
-      limit: 20,
+      limit: 100,
       data: [],
       offset: 0,
     } as OrbPagination<Sink>;

--- a/ui/src/app/pages/datasets/add/dataset.add.component.ts
+++ b/ui/src/app/pages/datasets/add/dataset.add.component.ts
@@ -172,11 +172,8 @@ export class DatasetAddComponent {
   getAvailableAgentGroups() {
     return new Promise((resolve) => {
       this.loading[CONFIG.GROUPS] = true;
-      const pageInfo = { ...AgentGroupsService.getDefaultPagination(), limit: 100 };
-      this.agentGroupsService
-        .getAgentGroups(pageInfo, false)
-        .subscribe((resp: OrbPagination<AgentGroup>) => {
-          this.availableAgentGroups = resp.data;
+      this.agentGroupsService.getAllAgentGroups().subscribe((resp: AgentGroup[]) => {
+          this.availableAgentGroups = resp;
           this.loading[CONFIG.GROUPS] = false;
 
           resolve(this.availableAgentGroups);

--- a/ui/src/app/pages/datasets/add/dataset.add.component.ts
+++ b/ui/src/app/pages/datasets/add/dataset.add.component.ts
@@ -1,17 +1,16 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 
-import { NotificationsService } from 'app/common/services/notifications/notifications.service';
-import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
-import { DatasetPoliciesService } from 'app/common/services/dataset/dataset.policies.service';
-import { AgentGroupsService } from 'app/common/services/agents/agent.groups.service';
-import { AgentPoliciesService } from 'app/common/services/agents/agent.policies.service';
-import { SinksService } from 'app/common/services/sinks/sinks.service';
-import { OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
 import { AgentPolicy } from 'app/common/interfaces/orb/agent.policy.interface';
+import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
 import { Sink } from 'app/common/interfaces/orb/sink.interface';
+import { AgentGroupsService } from 'app/common/services/agents/agent.groups.service';
+import { AgentPoliciesService } from 'app/common/services/agents/agent.policies.service';
+import { DatasetPoliciesService } from 'app/common/services/dataset/dataset.policies.service';
+import { NotificationsService } from 'app/common/services/notifications/notifications.service';
+import { SinksService } from 'app/common/services/sinks/sinks.service';
 import { STRINGS } from '../../../../assets/text/strings';
 
 const CONFIG = {
@@ -42,16 +41,15 @@ export class DatasetAddComponent {
   selectedPolicy: AgentPolicy;
 
   // stores user selected sinks
-  selectedSinks: { id: string, name?: string }[] = [];
+  selectedSinks: { id: string; name?: string }[] = [];
 
   isEdit: boolean;
 
   // #load controls
-  loading = Object.entries(CONFIG)
-    .reduce((acc, [value]) => {
-      acc[value] = false;
-      return acc;
-    }, {});
+  loading = Object.entries(CONFIG).reduce((acc, [value]) => {
+    acc[value] = false;
+    return acc;
+  }, {});
 
   datasetID: string;
 
@@ -77,42 +75,48 @@ export class DatasetAddComponent {
 
     this.getDatasetAvailableConfigList();
 
-    this.dataset = this.router.getCurrentNavigation().extras.state?.dataset as Dataset || null;
+    this.dataset =
+      (this.router.getCurrentNavigation().extras.state?.dataset as Dataset) ||
+      null;
     this.datasetID = this.route.snapshot.paramMap.get('id');
     this.isEdit = !!this.datasetID;
     this.loading[CONFIG.DATASET] = this.isEdit;
 
-    !!this.datasetID && datasetPoliciesService.getDatasetById(this.datasetID).subscribe(resp => {
-      this.dataset = resp;
-      this.loading[CONFIG.DATASET] = false;
-      this.updateForms();
-    });
+    !!this.datasetID &&
+      datasetPoliciesService
+        .getDatasetById(this.datasetID)
+        .subscribe((resp) => {
+          this.dataset = resp;
+          this.loading[CONFIG.DATASET] = false;
+          this.updateForms();
+        });
 
     this.updateForms();
   }
 
   readyForms() {
-    const {
-      name,
-      sink_ids,
-    } = this.dataset
-      = {
+    const { name, sink_ids } = (this.dataset = {
       name: '',
       agent_group_id: '',
       agent_policy_id: '',
       sink_ids: [],
-    } as Dataset;
+    } as Dataset);
 
-    this.selectedSinks = sink_ids.map<{ id: string, name: string }>((id) => {
+    this.selectedSinks = sink_ids.map<{ id: string; name: string }>((id) => {
       return {
         id,
-        name: this.availableSinks.length > 0 ?
-          this.availableSinks.find(sink => sink.id === id)?.name : '',
+        name:
+          this.availableSinks.length > 0
+            ? this.availableSinks.find((sink) => sink.id === id)?.name
+            : '',
       };
     });
 
     this.detailsFormGroup = this._formBuilder.group({
-      name: [name, [Validators.required, Validators.pattern('^[a-zA-Z_][a-zA-Z0-9_-]*$')]],
+      name: [
+        name,
+        [Validators.required, Validators.pattern('^[a-zA-Z_][a-zA-Z0-9_-]*$')],
+      ],
     });
     this.sinkFormGroup = this._formBuilder.group({
       selected_sink: ['', [Validators.minLength(1)]],
@@ -121,58 +125,88 @@ export class DatasetAddComponent {
 
   updateForms() {
     const {
-      name, agent_group_id, agent_policy_id,
+      name,
+      agent_group_id,
+      agent_policy_id,
       sink_ids,
-    } = this.dataset
-      = {
+    } = (this.dataset = {
       name: '',
       agent_group_id: '',
       agent_policy_id: '',
       sink_ids: [],
       ...this.dataset,
-    } as Dataset;
+    } as Dataset);
 
-    this.selectedSinks = sink_ids.map<{ id: string, name: string }>((id) => {
+    this.selectedSinks = sink_ids.map<{ id: string; name: string }>((id) => {
       return {
         id,
-        name: this.availableSinks.length > 0 ?
-          this.availableSinks.find(sink => sink.id === id)?.name : '',
+        name:
+          this.availableSinks.length > 0
+            ? this.availableSinks.find((sink) => sink.id === id)?.name
+            : '',
       };
     });
     if (this.availableSinks.length > 0 && this.selectedSinks.length > 0)
-      this.availableSinks = this.availableSinks.filter(sink => !this.selectedSinks.includes({ id: sink.id }));
+      this.availableSinks = this.availableSinks.filter(
+        (sink) => !this.selectedSinks.includes({ id: sink.id }),
+      );
 
     this.loading[CONFIG.SINKS] = true;
-    this.getAvailableSinks()
-      .catch(reason => console.warn(`Couldn't fetch available sinks. Reason: ${ reason }`));
+    this.getAvailableSinks().catch((reason) =>
+      console.warn(`Couldn't fetch available sinks. Reason: ${reason}`),
+    );
 
-    this.selectedGroup = !!agent_group_id && this.availableAgentGroups.find(agent => agent.id === agent_group_id);
-    this.selectedPolicy = !!agent_policy_id && this.availableAgentPolicies.find(policy => policy.id === agent_policy_id);
+    this.selectedGroup =
+      !!agent_group_id &&
+      this.availableAgentGroups.find((agent) => agent.id === agent_group_id);
+    this.selectedPolicy =
+      !!agent_policy_id &&
+      this.availableAgentPolicies.find(
+        (policy) => policy.id === agent_policy_id,
+      );
 
     this.detailsFormGroup.controls.name.patchValue(name);
     this.detailsFormGroup.updateValueAndValidity();
   }
 
   isLoading() {
-    return Object.values<boolean>(this.loading).reduce((prev, curr) => prev && curr);
+    return Object.values<boolean>(this.loading).reduce(
+      (prev, curr) => prev && curr,
+    );
   }
 
   getDatasetAvailableConfigList() {
-    Promise.all([this.getAvailableAgentGroups(), this.getAvailableAgentPolicies(), this.getAvailableSinks()])
-      .then(value => {
-        if (this.isEdit && this.dataset) {
-          this.updateForms();
-        }
-      }, reason => console.warn(`Cannot retrieve available configurations - reason: ${ JSON.parse(reason) }`))
-      .catch(reason => {
-        console.warn(`Cannot retrieve backend data - reason: ${ JSON.parse(reason) }`);
+    Promise.all([
+      this.getAvailableAgentGroups(),
+      this.getAvailableAgentPolicies(),
+      this.getAvailableSinks(),
+    ])
+      .then(
+        (value) => {
+          if (this.isEdit && this.dataset) {
+            this.updateForms();
+          }
+        },
+        (reason) =>
+          console.warn(
+            `Cannot retrieve available configurations - reason: ${JSON.parse(
+              reason,
+            )}`,
+          ),
+      )
+      .catch((reason) => {
+        console.warn(
+          `Cannot retrieve backend data - reason: ${JSON.parse(reason)}`,
+        );
       });
   }
 
   getAvailableAgentGroups() {
     return new Promise((resolve) => {
       this.loading[CONFIG.GROUPS] = true;
-      this.agentGroupsService.getAllAgentGroups().subscribe((resp: AgentGroup[]) => {
+      this.agentGroupsService
+        .getAllAgentGroups()
+        .subscribe((resp: AgentGroup[]) => {
           this.availableAgentGroups = resp;
           this.loading[CONFIG.GROUPS] = false;
 
@@ -184,7 +218,7 @@ export class DatasetAddComponent {
   getAvailableAgentPolicies() {
     return new Promise((resolve) => {
       this.loading[CONFIG.POLICIES] = true;
-      
+
       this.agentPoliciesService
         .getAllAgentPolicies()
         .subscribe((resp: AgentPolicy[]) => {
@@ -199,18 +233,20 @@ export class DatasetAddComponent {
   getAvailableSinks() {
     return new Promise((resolve) => {
       this.loading[CONFIG.SINKS] = true;
-      this.sinksService
-        .getAllSinks()
-        .subscribe((resp: Sink[]) => {
-          this.selectedSinks.forEach((sink) => {
-            sink.name = resp.find(anotherSink => anotherSink.id === sink.id).name;
-          });
-          const sinkIDMap = this.selectedSinks.map(sink => sink.id);
-          this.availableSinks = resp.filter(sink => !sinkIDMap.includes(sink.id));
-          this.loading[CONFIG.SINKS] = false;
-
-          resolve(this.availableSinks);
+      this.sinksService.getAllSinks().subscribe((resp: Sink[]) => {
+        this.selectedSinks.forEach((sink) => {
+          sink.name = resp.find(
+            (anotherSink) => anotherSink.id === sink.id,
+          ).name;
         });
+        const sinkIDMap = this.selectedSinks.map((sink) => sink.id);
+        this.availableSinks = resp.filter(
+          (sink) => !sinkIDMap.includes(sink.id),
+        );
+        this.loading[CONFIG.SINKS] = false;
+
+        resolve(this.availableSinks);
+      });
     });
   }
 
@@ -233,8 +269,9 @@ export class DatasetAddComponent {
 
   onPolicySelected(policy) {
     this.selectedPolicy = policy;
-    this.agentPoliciesService.getAgentPolicyById(policy.id)
-      .subscribe(fullPolicy => {
+    this.agentPoliciesService
+      .getAgentPolicyById(policy.id)
+      .subscribe((fullPolicy) => {
         this.selectedPolicy = { ...policy, ...fullPolicy };
       });
   }
@@ -244,14 +281,16 @@ export class DatasetAddComponent {
       name: this.detailsFormGroup.controls.name.value,
       agent_group_id: this.selectedGroup.id,
       agent_policy_id: this.selectedPolicy.id,
-      sink_ids: this.selectedSinks.map(sink => sink.id),
+      sink_ids: this.selectedSinks.map((sink) => sink.id),
     } as Dataset;
     if (this.isEdit) {
       // updating existing dataset
-      this.datasetPoliciesService.editDataset({ ...payload, id: this.datasetID }).subscribe(() => {
-        this.notificationsService.success('Dataset successfully updated', '');
-        this.goBack();
-      });
+      this.datasetPoliciesService
+        .editDataset({ ...payload, id: this.datasetID })
+        .subscribe(() => {
+          this.notificationsService.success('Dataset successfully updated', '');
+          this.goBack();
+        });
     } else {
       this.datasetPoliciesService.addDataset(payload).subscribe(() => {
         this.notificationsService.success('Dataset successfully created', '');

--- a/ui/src/app/pages/datasets/add/dataset.add.component.ts
+++ b/ui/src/app/pages/datasets/add/dataset.add.component.ts
@@ -184,11 +184,11 @@ export class DatasetAddComponent {
   getAvailableAgentPolicies() {
     return new Promise((resolve) => {
       this.loading[CONFIG.POLICIES] = true;
-      const pageInfo = { ...AgentPoliciesService.getDefaultPagination(), limit: 100 };
+      
       this.agentPoliciesService
-        .getAgentsPolicies(pageInfo, false)
-        .subscribe((resp: OrbPagination<AgentPolicy>) => {
-          this.availableAgentPolicies = resp.data;
+        .getAllAgentPolicies()
+        .subscribe((resp: AgentPolicy[]) => {
+          this.availableAgentPolicies = resp;
           this.loading[CONFIG.POLICIES] = false;
 
           resolve(this.availableAgentPolicies);
@@ -199,15 +199,14 @@ export class DatasetAddComponent {
   getAvailableSinks() {
     return new Promise((resolve) => {
       this.loading[CONFIG.SINKS] = true;
-      const pageInfo = { ...SinksService.getDefaultPagination(), limit: 100 };
       this.sinksService
-        .getSinks(pageInfo, false)
-        .subscribe((resp: OrbPagination<Sink>) => {
+        .getAllSinks()
+        .subscribe((resp: Sink[]) => {
           this.selectedSinks.forEach((sink) => {
-            sink.name = resp.data.find(anotherSink => anotherSink.id === sink.id).name;
+            sink.name = resp.find(anotherSink => anotherSink.id === sink.id).name;
           });
           const sinkIDMap = this.selectedSinks.map(sink => sink.id);
-          this.availableSinks = resp.data.filter(sink => !sinkIDMap.includes(sink.id));
+          this.availableSinks = resp.filter(sink => !sinkIDMap.includes(sink.id));
           this.loading[CONFIG.SINKS] = false;
 
           resolve(this.availableSinks);

--- a/ui/src/app/pages/datasets/dataset-from/dataset-from.component.ts
+++ b/ui/src/app/pages/datasets/dataset-from/dataset-from.component.ts
@@ -255,16 +255,15 @@ export class DatasetFromComponent implements OnInit {
   getAvailableSinks() {
     return new Promise((resolve) => {
       this.loading[CONFIG.SINKS] = true;
-      const pageInfo = {...SinksService.getDefaultPagination(), limit: 100};
       this.sinksService
-          .getSinks(pageInfo, false)
-          .subscribe((resp: OrbPagination<Sink>) => {
+          .getAllSinks()
+          .subscribe((resp:Sink[]) => {
             this._selectedSinks.forEach((sink) => {
-              sink.name = resp.data.find(
+              sink.name = resp.find(
                   anotherSink => anotherSink.id === sink.id).name;
             });
 
-            this.availableSinks = resp.data;
+            this.availableSinks = resp;
             this.updateUnselectedSinks();
 
             this.loading[CONFIG.SINKS] = false;

--- a/ui/src/app/pages/datasets/dataset-from/dataset-from.component.ts
+++ b/ui/src/app/pages/datasets/dataset-from/dataset-from.component.ts
@@ -1,18 +1,23 @@
-import {ChangeDetectorRef, Component, Input, OnInit} from '@angular/core';
-import {AbstractControl, FormBuilder, FormGroup, ValidatorFn, Validators} from '@angular/forms';
-import {NbDialogRef, NbDialogService} from '@nebular/theme';
-import {AgentGroup} from 'app/common/interfaces/orb/agent.group.interface';
-import {AgentPolicy} from 'app/common/interfaces/orb/agent.policy.interface';
-import {Dataset} from 'app/common/interfaces/orb/dataset.policy.interface';
-import {OrbPagination} from 'app/common/interfaces/orb/pagination.interface';
-import {Sink} from 'app/common/interfaces/orb/sink.interface';
-import {AgentGroupsService} from 'app/common/services/agents/agent.groups.service';
-import {AgentPoliciesService} from 'app/common/services/agents/agent.policies.service';
-import {DatasetPoliciesService} from 'app/common/services/dataset/dataset.policies.service';
-import {NotificationsService} from 'app/common/services/notifications/notifications.service';
-import {SinksService} from 'app/common/services/sinks/sinks.service';
-import {DatasetDeleteComponent} from 'app/pages/datasets/delete/dataset.delete.component';
-import {Observable, of} from 'rxjs';
+import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { NbDialogRef, NbDialogService } from '@nebular/theme';
+import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
+import { AgentPolicy } from 'app/common/interfaces/orb/agent.policy.interface';
+import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
+import { Sink } from 'app/common/interfaces/orb/sink.interface';
+import { AgentGroupsService } from 'app/common/services/agents/agent.groups.service';
+import { AgentPoliciesService } from 'app/common/services/agents/agent.policies.service';
+import { DatasetPoliciesService } from 'app/common/services/dataset/dataset.policies.service';
+import { NotificationsService } from 'app/common/services/notifications/notifications.service';
+import { SinksService } from 'app/common/services/sinks/sinks.service';
+import { DatasetDeleteComponent } from 'app/pages/datasets/delete/dataset.delete.component';
+import { Observable, of } from 'rxjs';
 
 const CONFIG = {
   SINKS: 'SINKS',
@@ -48,22 +53,21 @@ export class DatasetFromComponent implements OnInit {
   availableSinks: Sink[];
   unselectedSinks: Sink[];
   form: FormGroup;
-  loading = Object.entries(CONFIG)
-      .reduce((acc, [value]) => {
-        acc[value] = false;
-        return acc;
-      }, {});
+  loading = Object.entries(CONFIG).reduce((acc, [value]) => {
+    acc[value] = false;
+    return acc;
+  }, {});
 
   constructor(
-      private agentGroupsService: AgentGroupsService,
-      private agentPoliciesService: AgentPoliciesService,
-      private datasetService: DatasetPoliciesService,
-      private sinksService: SinksService,
-      private notificationsService: NotificationsService,
-      private fb: FormBuilder,
-      private dialogRef: NbDialogRef<DatasetFromComponent>,
-      private dialogService: NbDialogService,
-      private cdr: ChangeDetectorRef,
+    private agentGroupsService: AgentGroupsService,
+    private agentPoliciesService: AgentPoliciesService,
+    private datasetService: DatasetPoliciesService,
+    private sinksService: SinksService,
+    private notificationsService: NotificationsService,
+    private fb: FormBuilder,
+    private dialogRef: NbDialogRef<DatasetFromComponent>,
+    private dialogService: NbDialogService,
+    private cdr: ChangeDetectorRef,
   ) {
     this.isEdit = false;
     this.availableAgentGroups = [];
@@ -89,7 +93,7 @@ export class DatasetFromComponent implements OnInit {
 
   set selectedSinks(sinks: Sink[]) {
     this._selectedSinks = sinks;
-    this.sinkIDs = sinks.map(sink => sink.id);
+    this.sinkIDs = sinks.map((sink) => sink.id);
     this.form.controls.sink_ids.patchValue(this.sinkIDs);
     this.form.controls.sink_ids.markAsDirty();
     this.cdr.markForCheck();
@@ -97,64 +101,66 @@ export class DatasetFromComponent implements OnInit {
   }
 
   readyForms() {
-    const {
-      name,
-      agent_policy_id,
-      agent_group_id,
-      sink_ids,
-    } = this?.dataset || {
-      name: '',
-      agent_group_id: '',
-      agent_policy_id: '',
-      sink_ids: [],
-    } as Dataset;
+    const { name, agent_policy_id, agent_group_id, sink_ids } =
+      this?.dataset ||
+      ({
+        name: '',
+        agent_group_id: '',
+        agent_policy_id: '',
+        sink_ids: [],
+      } as Dataset);
 
     this.form = this.fb.group({
       name: [
-        name, [
-          Validators.required, Validators.pattern(
-              // https://github.com/ns1labs/orb/wiki/Architecture:-Common-Patterns#name-labels
-              // anything starting with alpha chars or underscore followed by any
-              // number of alphanumeric chars, dash '-' or underscore '_'. e.g.:
-              // valid: my_name, _name0, name__anything invalid: 0something, 000,
-              // 0_bla
-              '^[a-zA-Z_][a-zA-Z0-9_-]*$'),
+        name,
+        [
+          Validators.required,
+          Validators.pattern(
+            // https://github.com/ns1labs/orb/wiki/Architecture:-Common-Patterns#name-labels
+            // anything starting with alpha chars or underscore followed by any
+            // number of alphanumeric chars, dash '-' or underscore '_'. e.g.:
+            // valid: my_name, _name0, name__anything invalid: 0something, 000,
+            // 0_bla
+            '^[a-zA-Z_][a-zA-Z0-9_-]*$',
+          ),
         ],
       ],
-      agent_policy_id: [
-        agent_policy_id, [Validators.required],
-      ],
-      agent_group_id: [
-        agent_group_id, [Validators.required],
-      ],
+      agent_policy_id: [agent_policy_id, [Validators.required]],
+      agent_group_id: [agent_group_id, [Validators.required]],
       agent_group_name: [null, [this.groupNameValidator]],
       sink_ids: [sink_ids],
     });
   }
 
   groupNameValidator = (): ValidatorFn => {
-    return (control: AbstractControl) => this.availableAgentGroups
-        .filter((agent) => agent.name === control.value)
-        .length === 0 ? {noMatch: 'Select a valid agent'} : null;
+    return (control: AbstractControl) =>
+      this.availableAgentGroups.filter((agent) => agent.name === control.value)
+        .length === 0
+        ? { noMatch: 'Select a valid agent' }
+        : null;
   }
 
   updateFormSelectedAgentGroupId(groupName) {
-    const group = this.availableAgentGroups.filter((agent) => agent.name === groupName);
+    const group = this.availableAgentGroups.filter(
+      (agent) => agent.name === groupName,
+    );
     let id;
     if (group.length > 0) {
       id = group[0].id;
     }
-    this.form.patchValue({agent_group_id: id});
+    this.form.patchValue({ agent_group_id: id });
     this.cdr.markForCheck();
   }
 
   updateFormSelectedAgentGroupName(groupId) {
-    const group = this.availableAgentGroups.filter((agent) => agent.id === groupId);
+    const group = this.availableAgentGroups.filter(
+      (agent) => agent.id === groupId,
+    );
     let name;
     if (group.length > 0) {
       name = group[0].name;
     }
-    this.form.patchValue({agent_group_name: name});
+    this.form.patchValue({ agent_group_name: name });
     this.cdr.markForCheck();
   }
 
@@ -165,7 +171,6 @@ export class DatasetFromComponent implements OnInit {
 
   onSelectChangeGroupName(event) {
     this.onFilterGroup(event);
-
   }
 
   onFilterGroup(value) {
@@ -175,65 +180,79 @@ export class DatasetFromComponent implements OnInit {
   ngOnInit(): void {
     if (!!this.group) {
       this.selectedGroup = this.group.id;
-      this.form.patchValue({agent_group_id: this.group.id});
+      this.form.patchValue({ agent_group_id: this.group.id });
       this.form.controls.agent_group_id.disable();
     }
     if (!!this.policy) {
       this.selectedPolicy = this.policy.id;
-      this.form.patchValue({agent_policy_id: this.policy.id});
+      this.form.patchValue({ agent_policy_id: this.policy.id });
       this.form.controls.agent_policy_id.disable();
     }
     if (!!this.dataset) {
-      const {name, agent_group_id, agent_policy_id, sink_ids} = this.dataset;
+      const { name, agent_group_id, agent_policy_id, sink_ids } = this.dataset;
       this.selectedGroup = agent_group_id;
-      this.selectedSinks = this.availableSinks.filter(
-          sink => sink_ids.includes(sink.id));
+      this.selectedSinks = this.availableSinks.filter((sink) =>
+        sink_ids.includes(sink.id),
+      );
       this.selectedPolicy = agent_policy_id;
-      this.form.patchValue({name, agent_group_id, agent_policy_id, sink_ids});
+      this.form.patchValue({ name, agent_group_id, agent_policy_id, sink_ids });
       this.isEdit = true;
       this.form.controls.agent_group_id.disable();
       this.form.controls.agent_policy_id.disable();
 
       this.unselectedSinks = this.availableSinks.filter(
-          sink => !this._selectedSinks.includes(sink));
+        (sink) => !this._selectedSinks.includes(sink),
+      );
     }
   }
 
   updateUnselectedSinks() {
     this.unselectedSinks = this.availableSinks.filter(
-        sink => !this._selectedSinks.includes(sink));
+      (sink) => !this._selectedSinks.includes(sink),
+    );
   }
 
   getDatasetAvailableConfigList() {
     Promise.all([
       this.getAvailableAgentGroups(),
-      this.getAvailableAgentPolicies(), this.getAvailableSinks(),
+      this.getAvailableAgentPolicies(),
+      this.getAvailableSinks(),
     ])
-        .then(value => {
+      .then(
+        (value) => {
           // console.log('warning');
-        }, reason => console.warn(
-            `Cannot retrieve available configurations - reason: ${JSON.parse(
-                reason)}`))
-        .catch(reason => {
+        },
+        (reason) =>
           console.warn(
-              `Cannot retrieve backend data - reason: ${JSON.parse(reason)}`);
-        });
+            `Cannot retrieve available configurations - reason: ${JSON.parse(
+              reason,
+            )}`,
+          ),
+      )
+      .catch((reason) => {
+        console.warn(
+          `Cannot retrieve backend data - reason: ${JSON.parse(reason)}`,
+        );
+      });
   }
 
   getAvailableAgentGroups() {
     return new Promise((resolve) => {
       this.loading[CONFIG.GROUPS] = true;
-      this.agentGroupsService.getAllAgentGroups()
-          .subscribe((resp: AgentGroup[]) => {
-            this.availableAgentGroups = resp.sort((a, b) => a.name > b.name ? -1 : 1);
-            this.filteredAgentGroups$ = of(this.availableAgentGroups);
-            this.loading[CONFIG.GROUPS] = false;
+      this.agentGroupsService
+        .getAllAgentGroups()
+        .subscribe((resp: AgentGroup[]) => {
+          this.availableAgentGroups = resp.sort((a, b) =>
+            a.name > b.name ? -1 : 1,
+          );
+          this.filteredAgentGroups$ = of(this.availableAgentGroups);
+          this.loading[CONFIG.GROUPS] = false;
 
-            if (this.dataset?.agent_group_id) {
-              this.updateFormSelectedAgentGroupName(this.dataset.agent_group_id);
-            }
-            resolve(this.availableAgentGroups);
-          });
+          if (this.dataset?.agent_group_id) {
+            this.updateFormSelectedAgentGroupName(this.dataset.agent_group_id);
+          }
+          resolve(this.availableAgentGroups);
+        });
     });
   }
 
@@ -242,41 +261,40 @@ export class DatasetFromComponent implements OnInit {
       this.loading[CONFIG.POLICIES] = true;
 
       this.agentPoliciesService
-          .getAllAgentPolicies()
-          .subscribe((resp: AgentPolicy[]) => {
-            this.availableAgentPolicies = resp;
-            this.loading[CONFIG.POLICIES] = false;
+        .getAllAgentPolicies()
+        .subscribe((resp: AgentPolicy[]) => {
+          this.availableAgentPolicies = resp;
+          this.loading[CONFIG.POLICIES] = false;
 
-            resolve(this.availableAgentPolicies);
-          });
+          resolve(this.availableAgentPolicies);
+        });
     });
   }
 
   getAvailableSinks() {
     return new Promise((resolve) => {
       this.loading[CONFIG.SINKS] = true;
-      this.sinksService
-          .getAllSinks()
-          .subscribe((resp:Sink[]) => {
-            this._selectedSinks.forEach((sink) => {
-              sink.name = resp.find(
-                  anotherSink => anotherSink.id === sink.id).name;
-            });
+      this.sinksService.getAllSinks().subscribe((resp: Sink[]) => {
+        this._selectedSinks.forEach((sink) => {
+          sink.name = resp.find(
+            (anotherSink) => anotherSink.id === sink.id,
+          ).name;
+        });
 
-            this.availableSinks = resp;
-            this.updateUnselectedSinks();
+        this.availableSinks = resp;
+        this.updateUnselectedSinks();
 
-            this.loading[CONFIG.SINKS] = false;
+        this.loading[CONFIG.SINKS] = false;
 
-            resolve(this.availableSinks);
-          });
+        resolve(this.availableSinks);
+      });
     });
   }
 
-
   isLoading() {
-    return Object.values<boolean>(this.loading)
-        .reduce((prev, curr) => prev && curr);
+    return Object.values<boolean>(this.loading).reduce(
+      (prev, curr) => prev && curr,
+    );
   }
 
   onFormSubmit() {
@@ -284,16 +302,16 @@ export class DatasetFromComponent implements OnInit {
       name: this.form.controls.name.value,
       agent_group_id: this.form.controls.agent_group_id.value,
       agent_policy_id: this.form.controls.agent_policy_id.value,
-      sink_ids: this._selectedSinks.map(sink => sink.id),
+      sink_ids: this._selectedSinks.map((sink) => sink.id),
     } as Dataset;
     if (this.isEdit) {
       // updating existing dataset
-      this.datasetService.editDataset({...payload, id: this.dataset.id})
-          .subscribe(() => {
-            this.notificationsService.success('Dataset successfully updated',
-                '');
-            this.dialogRef.close('edited');
-          });
+      this.datasetService
+        .editDataset({ ...payload, id: this.dataset.id })
+        .subscribe(() => {
+          this.notificationsService.success('Dataset successfully updated', '');
+          this.dialogRef.close('edited');
+        });
     } else {
       this.datasetService.addDataset(payload).subscribe(() => {
         this.notificationsService.success('Dataset successfully created', '');
@@ -303,21 +321,23 @@ export class DatasetFromComponent implements OnInit {
   }
 
   onDelete() {
-    this.dialogService.open(DatasetDeleteComponent, {
-      context: {name: this.dataset.name},
-      autoFocus: true,
-      closeOnEsc: true,
-    }).onClose.subscribe(
-        confirm => {
-          if (confirm) {
-            this.datasetService.deleteDataset(this.dataset.id).subscribe(() => {
-              this.notificationsService.success('Dataset successfully deleted',
-                  '');
-              this.dialogRef.close('deleted');
-            });
-          }
-        },
-    );
+    this.dialogService
+      .open(DatasetDeleteComponent, {
+        context: { name: this.dataset.name },
+        autoFocus: true,
+        closeOnEsc: true,
+      })
+      .onClose.subscribe((confirm) => {
+        if (confirm) {
+          this.datasetService.deleteDataset(this.dataset.id).subscribe(() => {
+            this.notificationsService.success(
+              'Dataset successfully deleted',
+              '',
+            );
+            this.dialogRef.close('deleted');
+          });
+        }
+      });
   }
 
   onClose() {
@@ -329,11 +349,12 @@ export class DatasetFromComponent implements OnInit {
     if (value === '') {
       filtered = this.availableAgentGroups;
     } else {
-      filtered = this.availableAgentGroups.filter(group => group.name.includes(value));
+      filtered = this.availableAgentGroups.filter((group) =>
+        group.name.includes(value),
+      );
     }
     this.updateFormSelectedAgentGroupId(value);
 
     return filtered;
   }
-
 }

--- a/ui/src/app/pages/datasets/list/dataset.list.component.html
+++ b/ui/src/app/pages/datasets/list/dataset.list.component.html
@@ -7,16 +7,6 @@
   <div #tableWrapper class="d-flex flex-column mt-4">
     <div class="d-flex justify-content-between align-items-end mb-2">
       <div class="d-flex">
-        <p *ngIf=" paginationControls.data && paginationControls.data.length> 0"
-           class="dataset-info-regular mb-0">
-          You have {{paginationControls.total}} datasets initialized.
-        </p>
-        <p *ngIf="paginationControls.data && paginationControls.data.length === 0"
-           class="dataset-info-accent mb-0">
-          You have no datasets.
-        </p>
-      </div>
-      <div class="d-flex">
         <div class="mr-3">
           <nb-select
             (selectedChange)="onFilterSelected($event)"
@@ -55,10 +45,9 @@
       [columns]="columns"
       [footerHeight]="50"
       [headerHeight]="50"
-      [limit]="paginationControls.limit"
       [loadingIndicator]="loading"
       [rowHeight]="50"
-      [rows]="paginationControls.data"
+      
       [scrollbarV]="true"
       [sorts]="tableSorts"
       class="orb"

--- a/ui/src/app/pages/datasets/list/dataset.list.component.ts
+++ b/ui/src/app/pages/datasets/list/dataset.list.component.ts
@@ -31,8 +31,6 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
 
   loading = false;
 
-  paginationControls: OrbPagination<Dataset>;
-
   searchPlaceholder = 'Search by name';
 
   // templates
@@ -86,7 +84,7 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     private router: Router,
     private datasetPoliciesService: DatasetPoliciesService,
   ) {
-    this.paginationControls = DatasetPoliciesService.getDefaultPagination();
+    
   }
 
   ngAfterViewChecked() {
@@ -99,7 +97,7 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   ngOnInit() {
-    this.getAllDatasets();
+    
   }
 
   ngAfterViewInit() {
@@ -142,35 +140,6 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     this.cdr.detectChanges();
   }
 
-  getAllDatasets(): void {
-    this.datasetPoliciesService.clean();
-    this.datasetPoliciesService.getAllDatasets().subscribe(resp => {
-      this.paginationControls.data = resp;
-      this.paginationControls.total = resp.length;
-      this.paginationControls.offset = 0;
-      this.loading = false;
-      this.cdr.markForCheck();
-    });
-  }
-
-  getDatasets(pageInfo: NgxDatabalePageInfo = null): void {
-    const finalPageInfo = { ...pageInfo };
-    finalPageInfo.dir = 'desc';
-    finalPageInfo.order = 'name';
-    finalPageInfo.limit = this.paginationControls.limit;
-    finalPageInfo.offset = pageInfo?.offset * pageInfo?.limit || 0;
-
-    this.loading = true;
-    this.datasetPoliciesService.getDatasetPolicies(pageInfo).subscribe(
-      (resp: OrbPagination<Dataset>) => {
-        this.paginationControls = resp;
-        this.paginationControls.offset = pageInfo?.offset || 0;
-        this.paginationControls.total = resp.total;
-        this.loading = false;
-      },
-    );
-  }
-
   onOpenAdd() {
     this.router.navigate(['add'], {
       relativeTo: this.route.parent,
@@ -187,24 +156,6 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     );
   }
 
-  onFilterSelected(filter) {
-    this.searchPlaceholder = `Search by ${ filter.label }`;
-    this.filterValue = null;
-  }
-
-  applyFilter() {
-    if (!this.paginationControls || !this.paginationControls?.data) return;
-
-    if (!this.filterValue || this.filterValue === '') {
-      this.table.rows = this.paginationControls.data;
-    } else {
-      this.table.rows = this.paginationControls.data.filter(sink => this.filterValue.split(/[,;]+/gm).reduce((prev, curr) => {
-        return this.selectedFilter.filter(sink, curr) && prev;
-      }, true));
-    }
-    this.paginationControls.offset = 0;
-  }
-
   openDeleteModal(row: any) {
     const { id } = row;
     this.dialogService.open(DatasetDeleteComponent, {
@@ -216,7 +167,6 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
         if (confirm) {
           this.datasetPoliciesService.deleteDataset(id).subscribe(() => {
             this.notificationsService.success('Dataset successfully deleted', '');
-            this.getAllDatasets();
           });
         }
       },
@@ -231,8 +181,6 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     }).onClose.subscribe((resp) => {
       if (resp) {
         this.onOpenEdit(row);
-      } else {
-        this.getAllDatasets();
       }
     });
   }

--- a/ui/src/app/pages/datasets/list/dataset.list.component.ts
+++ b/ui/src/app/pages/datasets/list/dataset.list.component.ts
@@ -8,15 +8,17 @@ import {
   ViewChild,
 } from '@angular/core';
 
-import { DropdownFilterItem } from 'app/common/interfaces/mainflux.interface';
-import { ColumnMode, DatatableComponent, TableColumn } from '@swimlane/ngx-datatable';
-import { NgxDatabalePageInfo, OrbPagination } from 'app/common/interfaces/orb/pagination.interface';
-import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
-import { DatasetPoliciesService } from 'app/common/services/dataset/dataset.policies.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { DatasetDeleteComponent } from 'app/pages/datasets/delete/dataset.delete.component';
 import { NbDialogService } from '@nebular/theme';
+import {
+  ColumnMode,
+  DatatableComponent,
+  TableColumn,
+} from '@swimlane/ngx-datatable';
+import { DropdownFilterItem } from 'app/common/interfaces/mainflux.interface';
+import { DatasetPoliciesService } from 'app/common/services/dataset/dataset.policies.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
+import { DatasetDeleteComponent } from 'app/pages/datasets/delete/dataset.delete.component';
 import { DatasetDetailsComponent } from 'app/pages/datasets/details/dataset.details.component';
 
 @Component({
@@ -24,7 +26,8 @@ import { DatasetDetailsComponent } from 'app/pages/datasets/details/dataset.deta
   templateUrl: './dataset.list.component.html',
   styleUrls: ['./dataset.list.component.scss'],
 })
-export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChecked {
+export class DatasetListComponent
+  implements OnInit, AfterViewInit, AfterViewChecked {
   columnMode = ColumnMode;
 
   columns: TableColumn[];
@@ -55,7 +58,7 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
       label: 'Valid',
       prop: 'valid',
       selected: false,
-      filter: (dataset, valid) => `${ dataset?.valid }`.includes(name),
+      filter: (dataset, valid) => `${dataset?.valid}`.includes(name),
     },
   ];
 
@@ -83,12 +86,14 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     private route: ActivatedRoute,
     private router: Router,
     private datasetPoliciesService: DatasetPoliciesService,
-  ) {
-    
-  }
+  ) {}
 
   ngAfterViewChecked() {
-    if (this.table && this.table.recalculate && (this.tableWrapper.nativeElement.clientWidth !== this.currentComponentWidth)) {
+    if (
+      this.table &&
+      this.table.recalculate &&
+      this.tableWrapper.nativeElement.clientWidth !== this.currentComponentWidth
+    ) {
       this.currentComponentWidth = this.tableWrapper.nativeElement.clientWidth;
       this.table.recalculate();
       this.cdr.detectChanges();
@@ -96,9 +101,7 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
     }
   }
 
-  ngOnInit() {
-    
-  }
+  ngOnInit() {}
 
   ngAfterViewInit() {
     this.columns = [
@@ -147,41 +150,43 @@ export class DatasetListComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   onOpenEdit(dataset: any) {
-    this.router.navigate(
-      [`edit/${ dataset.id }`],
-      {
-        relativeTo: this.route.parent,
-        state: { dataset: dataset, edit: true },
-      },
-    );
+    this.router.navigate([`edit/${dataset.id}`], {
+      relativeTo: this.route.parent,
+      state: { dataset: dataset, edit: true },
+    });
   }
 
   openDeleteModal(row: any) {
     const { id } = row;
-    this.dialogService.open(DatasetDeleteComponent, {
-      context: { name: row.name },
-      autoFocus: true,
-      closeOnEsc: true,
-    }).onClose.subscribe(
-      confirm => {
+    this.dialogService
+      .open(DatasetDeleteComponent, {
+        context: { name: row.name },
+        autoFocus: true,
+        closeOnEsc: true,
+      })
+      .onClose.subscribe((confirm) => {
         if (confirm) {
           this.datasetPoliciesService.deleteDataset(id).subscribe(() => {
-            this.notificationsService.success('Dataset successfully deleted', '');
+            this.notificationsService.success(
+              'Dataset successfully deleted',
+              '',
+            );
           });
         }
-      },
-    );
+      });
   }
 
   openDetailsModal(row: any) {
-    this.dialogService.open(DatasetDetailsComponent, {
-      context: { dataset: row },
-      autoFocus: true,
-      closeOnEsc: true,
-    }).onClose.subscribe((resp) => {
-      if (resp) {
-        this.onOpenEdit(row);
-      }
-    });
+    this.dialogService
+      .open(DatasetDetailsComponent, {
+        context: { dataset: row },
+        autoFocus: true,
+        closeOnEsc: true,
+      })
+      .onClose.subscribe((resp) => {
+        if (resp) {
+          this.onOpenEdit(row);
+        }
+      });
   }
 }

--- a/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/list/agent.policy.list.component.ts
@@ -4,6 +4,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  OnDestroy,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -35,7 +36,7 @@ import { STRINGS } from '../../../../../assets/text/strings';
   styleUrls: ['./agent.policy.list.component.scss'],
 })
 export class AgentPolicyListComponent
-  implements AfterViewInit, AfterViewChecked {
+  implements AfterViewInit, AfterViewChecked, OnDestroy {
   strings = STRINGS.agents;
 
   columnMode = ColumnMode;
@@ -108,6 +109,10 @@ export class AgentPolicyListComponent
       this.filters$,
       this.filterOptions,
     );
+  }
+
+  ngOnDestroy(): void {
+    this.orb.killPolling.next();
   }
 
   ngAfterViewChecked() {

--- a/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.html
+++ b/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.html
@@ -51,6 +51,7 @@
   <div class="card-col col-8">
     <ngx-policy-datasets
       (refreshPolicy)="retrievePolicy()"
+      [datasets]="datasets"
       [policy]="policy"></ngx-policy-datasets>
     <ngx-policy-interface
       [(editMode)]="editMode.interface"

--- a/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { AgentPolicy } from 'app/common/interfaces/orb/agent.policy.interface';
+import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface'
 import {
   PolicyConfig,
 } from 'app/common/interfaces/orb/policy/config/policy.config.interface';
@@ -12,6 +13,7 @@ import {
 import {
   NotificationsService,
 } from 'app/common/services/notifications/notifications.service';
+import { OrbService } from 'app/common/services/orb.service'
 import {
   PolicyDetailsComponent,
 } from 'app/shared/components/orb/policy/policy-details/policy-details.component';
@@ -34,6 +36,8 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
   policyId: string;
 
   policy: AgentPolicy;
+  
+  datasets: Dataset[];
 
   policySubscription: Subscription;
 
@@ -49,9 +53,11 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private policiesService: AgentPoliciesService,
+    private orb: OrbService,
     private cdr: ChangeDetectorRef,
     private notifications: NotificationsService,
-  ) {}
+  ) {
+  }
 
   ngOnInit() {
     this.isLoading = true;
@@ -135,10 +141,10 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
   }
 
   retrievePolicy() {
-    this.policySubscription = this.policiesService
-      .getAgentPolicyById(this.policyId)
-      .subscribe(policy => {
+    this.policySubscription = this.orb.getPolicyFullView(this.policyId)
+      .subscribe(({policy, datasets}) => {
         this.policy = policy;
+        this.datasets = datasets;
         this.isLoading = false;
         this.cdr.markForCheck();
       });

--- a/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.ts
+++ b/ui/src/app/pages/datasets/policies.agent/view/agent.policy.view.component.ts
@@ -1,25 +1,19 @@
 import {
-  ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild,
+  ChangeDetectorRef,
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewChild,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { AgentPolicy } from 'app/common/interfaces/orb/agent.policy.interface';
-import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface'
-import {
-  PolicyConfig,
-} from 'app/common/interfaces/orb/policy/config/policy.config.interface';
-import {
-  AgentPoliciesService,
-} from 'app/common/services/agents/agent.policies.service';
-import {
-  NotificationsService,
-} from 'app/common/services/notifications/notifications.service';
-import { OrbService } from 'app/common/services/orb.service'
-import {
-  PolicyDetailsComponent,
-} from 'app/shared/components/orb/policy/policy-details/policy-details.component';
-import {
-  PolicyInterfaceComponent,
-} from 'app/shared/components/orb/policy/policy-interface/policy-interface.component';
+import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
+import { PolicyConfig } from 'app/common/interfaces/orb/policy/config/policy.config.interface';
+import { AgentPoliciesService } from 'app/common/services/agents/agent.policies.service';
+import { NotificationsService } from 'app/common/services/notifications/notifications.service';
+import { OrbService } from 'app/common/services/orb.service';
+import { PolicyDetailsComponent } from 'app/shared/components/orb/policy/policy-details/policy-details.component';
+import { PolicyInterfaceComponent } from 'app/shared/components/orb/policy/policy-interface/policy-interface.component';
 import { STRINGS } from 'assets/text/strings';
 import { Subscription } from 'rxjs';
 
@@ -36,19 +30,20 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
   policyId: string;
 
   policy: AgentPolicy;
-  
+
   datasets: Dataset[];
 
   policySubscription: Subscription;
 
   editMode = {
-    details: false, interface: false,
+    details: false,
+    interface: false,
   };
 
   @ViewChild(PolicyDetailsComponent) detailsComponent: PolicyDetailsComponent;
 
-  @ViewChild(
-    PolicyInterfaceComponent) interfaceComponent: PolicyInterfaceComponent;
+  @ViewChild(PolicyInterfaceComponent)
+  interfaceComponent: PolicyInterfaceComponent;
 
   constructor(
     private route: ActivatedRoute,
@@ -56,8 +51,7 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
     private orb: OrbService,
     private cdr: ChangeDetectorRef,
     private notifications: NotificationsService,
-  ) {
-  }
+  ) {}
 
   ngOnInit() {
     this.isLoading = true;
@@ -66,16 +60,20 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
   }
 
   isEditMode() {
-    return Object.values(this.editMode)
-      .reduce((prev, cur) => prev || cur, false);
+    return Object.values(this.editMode).reduce(
+      (prev, cur) => prev || cur,
+      false,
+    );
   }
 
   canSave() {
     const detailsValid = this.editMode.details
-      ? this.detailsComponent?.formGroup?.status === 'VALID' : true;
+      ? this.detailsComponent?.formGroup?.status === 'VALID'
+      : true;
 
     const interfaceValid = this.editMode.interface
-      ? this.interfaceComponent?.formControl?.status === 'VALID' : true;
+      ? this.interfaceComponent?.formControl?.status === 'VALID'
+      : true;
 
     return detailsValid && interfaceValid;
   }
@@ -101,9 +99,9 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
     const policyInterface = this.interfaceComponent.code;
 
     // trying to work around rest api
-    const detailsPartial = !!this.editMode.details && {
+    const detailsPartial = (!!this.editMode.details && {
       ...policyDetails,
-    } || { name, description };
+    }) || { name, description };
 
     let interfacePartial = {};
 
@@ -129,20 +127,23 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
     const payload = {
       ...detailsPartial,
       ...interfacePartial,
-      version, id, tags, backend,
+      version,
+      id,
+      tags,
+      backend,
     } as AgentPolicy;
 
-    this.policiesService.editAgentPolicy(payload)
-      .subscribe(resp => {
-        this.discard();
-        this.retrievePolicy();
-        this.cdr.markForCheck();
-      });
+    this.policiesService.editAgentPolicy(payload).subscribe((resp) => {
+      this.discard();
+      this.retrievePolicy();
+      this.cdr.markForCheck();
+    });
   }
 
   retrievePolicy() {
-    this.policySubscription = this.orb.getPolicyFullView(this.policyId)
-      .subscribe(({policy, datasets}) => {
+    this.policySubscription = this.orb
+      .getPolicyFullView(this.policyId)
+      .subscribe(({ policy, datasets }) => {
         this.policy = policy;
         this.datasets = datasets;
         this.isLoading = false;
@@ -151,11 +152,14 @@ export class AgentPolicyViewComponent implements OnInit, OnDestroy {
   }
 
   duplicatePolicy() {
-    this.policiesService.duplicateAgentPolicy(this.policyId || this.policy.id)
-      .subscribe(resp => {
+    this.policiesService
+      .duplicateAgentPolicy(this.policyId || this.policy.id)
+      .subscribe((resp) => {
         if (resp?.id) {
-          this.notifications.success('Agent Policy Duplicated',
-            `New Agent Policy Name: ${resp?.name}`);
+          this.notifications.success(
+            'Agent Policy Duplicated',
+            `New Agent Policy Name: ${resp?.name}`,
+          );
         }
       });
   }

--- a/ui/src/app/pages/fleet/agents/list/agent.list.component.ts
+++ b/ui/src/app/pages/fleet/agents/list/agent.list.component.ts
@@ -3,6 +3,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  OnDestroy,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -36,7 +37,7 @@ import { Observable } from 'rxjs';
   templateUrl: './agent.list.component.html',
   styleUrls: ['./agent.list.component.scss'],
 })
-export class AgentListComponent implements AfterViewInit, AfterViewChecked {
+export class AgentListComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
   strings = STRINGS.agents;
 
   columnMode = ColumnMode;
@@ -116,6 +117,10 @@ export class AgentListComponent implements AfterViewInit, AfterViewChecked {
       this.filters$,
       this.filterOptions,
     );
+  }
+
+  ngOnDestroy() {
+    this.orb.killPolling.next();
   }
 
   ngAfterViewChecked() {

--- a/ui/src/app/pages/fleet/groups/list/agent.group.list.component.ts
+++ b/ui/src/app/pages/fleet/groups/list/agent.group.list.component.ts
@@ -3,6 +3,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  OnDestroy,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -38,7 +39,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./agent.group.list.component.scss'],
 })
 export class AgentGroupListComponent
-  implements AfterViewInit, AfterViewChecked {
+  implements AfterViewInit, AfterViewChecked, OnDestroy {
   strings = STRINGS.agentGroups;
 
   columnMode = ColumnMode;
@@ -123,6 +124,10 @@ export class AgentGroupListComponent
       this.filters$,
       this.filterOptions,
     );
+  }
+
+  ngOnDestroy(): void {
+    this.orb.killPolling.next();
   }
 
   ngAfterViewChecked() {

--- a/ui/src/app/pages/sinks/list/sink.list.component.ts
+++ b/ui/src/app/pages/sinks/list/sink.list.component.ts
@@ -3,6 +3,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  OnDestroy,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -40,7 +41,7 @@ import { Observable } from 'rxjs';
   templateUrl: './sink.list.component.html',
   styleUrls: ['./sink.list.component.scss'],
 })
-export class SinkListComponent implements AfterViewInit, AfterViewChecked {
+export class SinkListComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
   strings = STRINGS.sink;
 
   columnMode = ColumnMode;
@@ -124,6 +125,10 @@ export class SinkListComponent implements AfterViewInit, AfterViewChecked {
       this.filters$,
       this.filterOptions,
     );
+  }
+
+  ngOnDestroy(): void {
+    this.orb.killPolling.next();
   }
 
   ngAfterViewChecked() {

--- a/ui/src/app/shared/components/orb/dataset/grouped-agents/grouped-agents.component.ts
+++ b/ui/src/app/shared/components/orb/dataset/grouped-agents/grouped-agents.component.ts
@@ -57,7 +57,7 @@ export class GroupedAgentsComponent implements OnInit, OnChanges {
 
       this.agentsService.getAllAgents(tags)
         .subscribe(agents => {
-          this.agents = agents;
+          this.agents = agents.data;
           this.isLoading = false;
         });
     }

--- a/ui/src/app/shared/components/orb/dataset/grouped-agents/grouped-agents.component.ts
+++ b/ui/src/app/shared/components/orb/dataset/grouped-agents/grouped-agents.component.ts
@@ -57,7 +57,7 @@ export class GroupedAgentsComponent implements OnInit, OnChanges {
 
       this.agentsService.getAllAgents(tags)
         .subscribe(agents => {
-          this.agents = agents.data;
+          this.agents = agents;
           this.isLoading = false;
         });
     }

--- a/ui/src/app/shared/components/orb/policy/policy-datasets/policy-datasets.component.html
+++ b/ui/src/app/shared/components/orb/policy/policy-datasets/policy-datasets.component.html
@@ -10,7 +10,7 @@
     </nb-card-header>
     <nb-card-body>
         <div class="col-12">
-            <div #tableWrapper class="d-flex flex-column mt-4">
+            <div #tableWrapper class="tableWrapper">
                 <ngx-datatable
                     #table
                     [columnMode]="columnMode.flex"
@@ -22,8 +22,7 @@
                     [rows]="datasets"
                     [scrollbarV]="true"
                     [sorts]="tableSorts"
-                    class="orb"
-                    style="height: 100%">
+                    class="orb orb-table-small">
                 </ngx-datatable>
             </div>
 

--- a/ui/src/app/shared/components/orb/policy/policy-datasets/policy-datasets.component.ts
+++ b/ui/src/app/shared/components/orb/policy/policy-datasets/policy-datasets.component.ts
@@ -1,248 +1,244 @@
 import {
-    AfterViewChecked,
-    AfterViewInit,
-    ChangeDetectorRef,
-    Component,
-    EventEmitter,
-    Input,
-    OnChanges,
-    OnDestroy,
-    OnInit,
-    Output,
-    SimpleChanges,
-    TemplateRef,
-    ViewChild,
+  AfterViewChecked,
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  TemplateRef,
+  ViewChild,
 } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { NbDialogService } from '@nebular/theme';
-import { ColumnMode, DatatableComponent, TableColumn } from '@swimlane/ngx-datatable';
-import { AgentGroup } from 'app/common/interfaces/orb/agent.group.interface';
+import {
+  ColumnMode,
+  DatatableComponent,
+  TableColumn,
+} from '@swimlane/ngx-datatable';
 import { AgentPolicy } from 'app/common/interfaces/orb/agent.policy.interface';
 import { Dataset } from 'app/common/interfaces/orb/dataset.policy.interface';
-import { Sink } from 'app/common/interfaces/orb/sink.interface';
-import { ActivatedRoute, Router } from '@angular/router';
-import { AgentGroupsService } from 'app/common/services/agents/agent.groups.service';
-import { DatasetPoliciesService } from 'app/common/services/dataset/dataset.policies.service';
-import { SinksService } from 'app/common/services/sinks/sinks.service';
 import { DatasetFromComponent } from 'app/pages/datasets/dataset-from/dataset-from.component';
-import { Subscription } from 'rxjs';
-import { concatMap } from 'rxjs/operators';
 import { AgentGroupDetailsComponent } from 'app/pages/fleet/groups/details/agent.group.details.component';
 import { SinkDetailsComponent } from 'app/pages/sinks/details/sink.details.component';
+import { Subscription } from 'rxjs';
 
 @Component({
-    selector: 'ngx-policy-datasets',
-    templateUrl: './policy-datasets.component.html',
-    styleUrls: ['./policy-datasets.component.scss'],
+  selector: 'ngx-policy-datasets',
+  templateUrl: './policy-datasets.component.html',
+  styleUrls: ['./policy-datasets.component.scss'],
 })
-export class PolicyDatasetsComponent implements OnInit, OnDestroy,
-    AfterViewInit, AfterViewChecked, OnChanges {
-    @Input()
-    datasets: Dataset[];
+export class PolicyDatasetsComponent
+  implements OnInit, OnDestroy, AfterViewInit, AfterViewChecked, OnChanges {
+  @Input()
+  datasets: Dataset[];
 
-    @Input()
-    policy: AgentPolicy
+  @Input()
+  policy: AgentPolicy;
 
-    @Output()
-    refreshPolicy: EventEmitter<string>;
+  @Output()
+  refreshPolicy: EventEmitter<string>;
 
-    isLoading: boolean;
+  isLoading: boolean;
 
-    subscription: Subscription;
+  subscription: Subscription;
 
-    errors;
+  errors;
 
-    columnMode = ColumnMode;
+  columnMode = ColumnMode;
 
-    columns: TableColumn[];
+  columns: TableColumn[];
 
-    tableSorts = [
-        {
-            prop: 'name',
-            dir: 'asc',
-        },
+  tableSorts = [
+    {
+      prop: 'name',
+      dir: 'asc',
+    },
+  ];
+
+  // templates
+  @ViewChild('nameTemplateCell') nameTemplateCell: TemplateRef<any>;
+
+  @ViewChild('groupTemplateCell') groupTemplateCell: TemplateRef<any>;
+
+  @ViewChild('validTemplateCell') validTemplateCell: TemplateRef<any>;
+
+  @ViewChild('sinksTemplateCell') sinksTemplateCell: TemplateRef<any>;
+
+  @ViewChild('tableWrapper') tableWrapper;
+
+  @ViewChild(DatatableComponent) table: DatatableComponent;
+
+  private currentComponentWidth;
+
+  constructor(
+    private dialogService: NbDialogService,
+    private cdr: ChangeDetectorRef,
+    protected router: Router,
+    protected route: ActivatedRoute,
+  ) {
+    this.refreshPolicy = new EventEmitter<string>();
+    this.datasets = [];
+    this.errors = {};
+  }
+
+  ngOnInit(): void {}
+
+  ngOnChanges(changes: SimpleChanges) {}
+
+  ngAfterViewInit() {
+    this.columns = [
+      {
+        prop: 'name',
+        name: 'Name',
+        resizeable: false,
+        canAutoResize: true,
+        minWidth: 90,
+        width: 120,
+        maxWidth: 150,
+        flexGrow: 3,
+        cellTemplate: this.nameTemplateCell,
+      },
+      {
+        prop: 'agent_group',
+        name: 'Agent Group',
+        resizeable: false,
+        canAutoResize: true,
+        minWidth: 90,
+        width: 120,
+        maxWidth: 150,
+        flexGrow: 3,
+        cellTemplate: this.groupTemplateCell,
+      },
+      {
+        prop: 'valid',
+        name: 'Valid',
+        resizeable: false,
+        canAutoResize: true,
+        minWidth: 65,
+        width: 80,
+        maxWidth: 100,
+        flexGrow: 2,
+        cellTemplate: this.validTemplateCell,
+      },
+      {
+        prop: 'sinks',
+        name: 'Sinks',
+        resizeable: false,
+        canAutoResize: true,
+        minWidth: 200,
+        width: 300,
+        maxWidth: 500,
+        flexGrow: 6,
+        cellTemplate: this.sinksTemplateCell,
+      },
     ];
 
-    // templates
-    @ViewChild('nameTemplateCell') nameTemplateCell: TemplateRef<any>;
+    this.cdr.detectChanges();
+  }
 
-    @ViewChild('groupTemplateCell') groupTemplateCell: TemplateRef<any>;
-
-    @ViewChild('validTemplateCell') validTemplateCell: TemplateRef<any>;
-
-    @ViewChild('sinksTemplateCell') sinksTemplateCell: TemplateRef<any>;
-
-    @ViewChild('tableWrapper') tableWrapper;
-
-    @ViewChild(DatatableComponent) table: DatatableComponent;
-
-    private currentComponentWidth;
-
-    constructor(
-        private dialogService: NbDialogService,
-        private cdr: ChangeDetectorRef,
-        protected router: Router,
-        protected route: ActivatedRoute,
+  ngAfterViewChecked() {
+    if (
+      this.table &&
+      this.table.recalculate &&
+      this.tableWrapper.nativeElement.clientWidth !== this.currentComponentWidth
     ) {
-        this.refreshPolicy = new EventEmitter<string>();
-        this.datasets = [];
-        this.errors = {};
+      this.currentComponentWidth = this.tableWrapper.nativeElement.clientWidth;
+      this.table.recalculate();
+      this.cdr.detectChanges();
+      window.dispatchEvent(new Event('resize'));
     }
+  }
 
-    ngOnInit(): void {
-        
-    }
-
-    ngOnChanges(changes: SimpleChanges) {
-        
-    }
-
-    ngAfterViewInit() {
-        this.columns = [
-            {
-                prop: 'name',
-                name: 'Name',
-                resizeable: false,
-                canAutoResize: true,
-                minWidth: 90,
-                width: 120,
-                maxWidth: 150,
-                flexGrow: 3,
-                cellTemplate: this.nameTemplateCell,
-            },
-            {
-                prop: 'agent_group',
-                name: 'Agent Group',
-                resizeable: false,
-                canAutoResize: true,
-                minWidth: 90,
-                width: 120,
-                maxWidth: 150,
-                flexGrow: 3,
-                cellTemplate: this.groupTemplateCell,
-            },
-            {
-                prop: 'valid',
-                name: 'Valid',
-                resizeable: false,
-                canAutoResize: true,
-                minWidth: 65,
-                width: 80,
-                maxWidth: 100,
-                flexGrow: 2,
-                cellTemplate: this.validTemplateCell,
-            },
-            {
-                prop: 'sinks',
-                name: 'Sinks',
-                resizeable: false,
-                canAutoResize: true,
-                minWidth: 200,
-                width: 300,
-                maxWidth: 500,
-                flexGrow: 6,
-                cellTemplate: this.sinksTemplateCell,
-            },
-        ];
-
-        this.cdr.detectChanges();
-    }
-
-    ngAfterViewChecked() {
-        if (this.table && this.table.recalculate && (
-            this.tableWrapper.nativeElement.clientWidth !== this.currentComponentWidth
-        )) {
-            this.currentComponentWidth = this.tableWrapper.nativeElement.clientWidth;
-            this.table.recalculate();
-            this.cdr.detectChanges();
-            window.dispatchEvent(new Event('resize'));
+  onCreateDataset() {
+    this.dialogService
+      .open(DatasetFromComponent, {
+        autoFocus: true,
+        closeOnEsc: true,
+        context: {
+          policy: this.policy,
+        },
+        hasScroll: false,
+        hasBackdrop: true,
+        closeOnBackdropClick: true,
+      })
+      .onClose.subscribe((resp) => {
+        if (resp === 'created') {
+          this.refreshPolicy.emit('refresh-from-dataset');
         }
-    }
+      });
+  }
 
+  onOpenEdit(dataset) {
+    this.dialogService
+      .open(DatasetFromComponent, {
+        autoFocus: true,
+        closeOnEsc: false,
+        context: {
+          dataset,
+        },
+        hasScroll: false,
+        closeOnBackdropClick: true,
+        hasBackdrop: true,
+      })
+      .onClose.subscribe((resp) => {
+        if (resp === 'changed' || resp === 'deleted') {
+          this.refreshPolicy.emit('refresh-from-dataset');
+        }
+      });
+  }
 
-    onCreateDataset() {
-        this.dialogService.open(DatasetFromComponent,
-            {
-                autoFocus: true,
-                closeOnEsc: true,
-                context: {
-                    policy: this.policy,
-                },
-                hasScroll: false,
-                hasBackdrop: true,
-                closeOnBackdropClick: true,
-            }).onClose.subscribe(resp => {
-            if (resp === 'created') {
-                this.refreshPolicy.emit('refresh-from-dataset');
-            }
-        });
-    }
+  onOpenGroupDetails(agentGroup) {
+    this.dialogService
+      .open(AgentGroupDetailsComponent, {
+        autoFocus: true,
+        closeOnEsc: true,
+        context: { agentGroup },
+        hasScroll: false,
+        hasBackdrop: false,
+      })
+      .onClose.subscribe((resp) => {
+        if (resp) {
+          this.onOpenEditAgentGroup(agentGroup);
+        }
+      });
+  }
 
-    onOpenEdit(dataset) {
-        this.dialogService.open(DatasetFromComponent,
-            {
-                autoFocus: true,
-                closeOnEsc: false,
-                context: {
-                    dataset,
-                },
-                hasScroll: false,
-                closeOnBackdropClick: true,
-                hasBackdrop: true,
-            }).onClose.subscribe(resp => {
-            if (resp === 'changed' || resp === 'deleted') {
-                this.refreshPolicy.emit('refresh-from-dataset');
-            }
-        });
-    }
+  onOpenEditAgentGroup(agentGroup: any) {
+    this.router.navigate([`/pages/fleet/groups/edit/${agentGroup.id}`], {
+      state: { agentGroup: agentGroup, edit: true },
+      relativeTo: this.route,
+    });
+  }
 
-    onOpenGroupDetails(agentGroup) {
-        this.dialogService.open(AgentGroupDetailsComponent,
-            {
-                autoFocus: true,
-                closeOnEsc: true,
-                context: {agentGroup},
-                hasScroll: false,
-                hasBackdrop: false,
-            }).onClose.subscribe((resp) => {
-            if (resp) {
-                this.onOpenEditAgentGroup(agentGroup);
-            }
-        });
-    }
+  onOpenSinkDetails(sink) {
+    this.dialogService
+      .open(SinkDetailsComponent, {
+        autoFocus: true,
+        closeOnEsc: true,
+        context: { sink },
+        hasScroll: false,
+        hasBackdrop: false,
+      })
+      .onClose.subscribe((resp) => {
+        if (resp) {
+          this.onOpenEditSink(sink);
+        }
+      });
+  }
 
-    onOpenEditAgentGroup(agentGroup: any) {
-        this.router.navigate([`/pages/fleet/groups/edit/${agentGroup.id}`], {
-            state: {agentGroup: agentGroup, edit: true},
-            relativeTo: this.route,
-        });
-    }
+  onOpenEditSink(sink: any) {
+    this.router.navigate([`pages/sinks/edit/${sink.id}`], {
+      relativeTo: this.route,
+      state: { sink: sink, edit: true },
+    });
+  }
 
-    onOpenSinkDetails(sink) {
-        this.dialogService.open(SinkDetailsComponent,
-            {
-                autoFocus: true,
-                closeOnEsc: true,
-                context: {sink},
-                hasScroll: false,
-                hasBackdrop: false,
-            }).onClose.subscribe((resp) => {
-            if (resp) {
-                this.onOpenEditSink(sink);
-            }
-        });
-    }
-
-    onOpenEditSink(sink: any) {
-        this.router.navigate(
-            [`pages/sinks/edit/${sink.id}`],
-            {
-                relativeTo: this.route,
-                state: {sink: sink, edit: true},
-            },
-        );
-    }
-
-    ngOnDestroy() {
-        this.subscription?.unsubscribe();
-    }
+  ngOnDestroy() {
+    this.subscription?.unsubscribe();
+  }
 }


### PR DESCRIPTION
* fixed expand cycle 'dir' param undefined - root cause of issue before deploy
* fixed condition on expand cycle, adopted scan() in favor of reduce()
* fixed keep watching on observable of another page when not needed.
* fixed dataset add component only querying the first 100 items
* fixed group service, group listing page errors
* fixed sink service
* fixed policy service
* fixed dataset service
* fixed agent policy view dataset list
* improved load time for agent policy view

---

TODO rewrite cache into the loop
